### PR TITLE
Expose vault through Traefik

### DIFF
--- a/docker-image/ansible/files/consul/consul.conf.j2
+++ b/docker-image/ansible/files/consul/consul.conf.j2
@@ -1,7 +1,7 @@
 {
   "data_dir": "/var/lib/consul",
   "log_level": "INFO",
-  "ui": {{ (inventory_hostname in groups["control"])|bool|to_json }},
+  "ui": {{ (inventory_hostname in groups["edge"])|bool|to_json }},
   "client_addr": "{{ private_ipv4 }}",
   "advertise_addr": "{{ private_ipv4 }}",
   "bind_addr": "{{ private_ipv4 }}",

--- a/docker-image/ansible/files/swarm/traefik.yml.j2
+++ b/docker-image/ansible/files/swarm/traefik.yml.j2
@@ -7,6 +7,7 @@ services:
     image: {{ traefik_image }}
     command: >
       --web
+      --logLevel=WARNING
       --docker
       --docker.swarmmode
       --docker.domain={{ traefik_domain }}
@@ -22,9 +23,12 @@ services:
       - net
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      # Consul client certificates
       - "{{ consul_client_ca_file }}:/etc/ssl/certs/consul/ca.pem:ro"
       - "{{ consul_client_cert_file }}:/etc/ssl/certs/consul/cert.pem:ro"
       - "{{ consul_client_key_file }}:/etc/ssl/certs/consul/key.pem:ro"
+      # Extra CAs from our architecture
+      - "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/ssl/certs/ca-certificates.crt:ro"
     deploy:
       mode: global
       placement:

--- a/docker-image/ansible/playbooks/primary.yml
+++ b/docker-image/ansible/playbooks/primary.yml
@@ -112,3 +112,19 @@
           restart_policy: always
           published_ports:
             - "5000:5000"
+
+### CA Certificates
+# Make sure that every nodes have all intermediate CAs installed in their trust
+# database, this allows us to have containers talk to vault/consul/etc...
+# without complaining about self-signed stuff
+###
+- hosts: all
+  become: true
+  roles:
+    - vault-auth
+    - role: register-ca
+      backend: consul
+    - role: register-ca
+      backend: docker
+    - role: register-ca
+      backend: vault

--- a/docker-image/ansible/playbooks/swarm.yml
+++ b/docker-image/ansible/playbooks/swarm.yml
@@ -27,7 +27,7 @@
 ### Traefik
 # Starts traefik in swarm mode
 ###
-- hosts: control
+- hosts: control[0]
   become: true
   tasks:
     - name: "Upload traefik stack file"
@@ -35,6 +35,23 @@
         dest: "{{ traefik_file }}"
         src: "{{ playbook_dir }}/../files/swarm/traefik.yml.j2"
     - name: "Start traefik on the cluster"
-      run_once: true
       shell: "docker stack deploy -c '{{ traefik_file }}' {{ traefik_stack }}"
+
+    # Here we expose a couple extra things from the primary architecture
+    - name: "Allow access to vault through traefik"
+      consul_kv:
+        host: "127.0.0.1"
+        key: "{{ item.key }}"
+        value: "{{ item.value }}"
+      run_once: true
+      with_items:
+        # vault
+        - key: "traefik/backends/vault/servers/vault/url"
+          value: "https://{{ group_ipv4.control[0] }}:8200"
+        - key: "traefik/backends/vault/servers/vault/weight"
+          value: "1"
+        - key: "traefik/frontends/vault/backend"
+          value: "vault"
+        - key: "traefik/frontends/vault/routes/vault/rule"
+          value: "Host:vault.{{ consul_domain }}"
 

--- a/docker-image/ansible/roles/docker/handlers/main.yml
+++ b/docker-image/ansible/roles/docker/handlers/main.yml
@@ -6,3 +6,4 @@
   service:
     name: docker
     state: restarted
+

--- a/docker-image/ansible/roles/docker/tasks/main.yml
+++ b/docker-image/ansible/roles/docker/tasks/main.yml
@@ -24,8 +24,6 @@
     or cert_rotate_all|default(false)|bool
   include_role:
     name: generate-tls
-  notify:
-    - Restart docker
   vars:
     pki:
       # docker backend
@@ -41,7 +39,9 @@
       request_data:
         common_name: "{{ inventory_hostname }}.node.{{ consul_datacenter }}.{{ consul_domain }}"
         alt_names: "docker.service.{{ consul_datacenter }}.{{ consul_domain }},swarm.service.{{ consul_datacenter }}.{{ consul_domain }},*.swarm.service.{{ consul_datacenter }}.{{ consul_domain }}"
-        ip_sans: "{{ private_ipv4 }}"
+        ip_sans: "{{ private_ipv4 }},{{ ansible_ssh_host }}"
+      notify:
+        - Restart docker
 
 - name: "Generate client TLS certificates"
   when: >

--- a/docker-image/ansible/roles/register-ca/tasks/main.yml
+++ b/docker-image/ansible/roles/register-ca/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: "Fetch remote CA"
+  uri:
+    HEADER_X-Vault-Token: "{{ vault_token }}"
+    url: "http://127.0.0.1:8200/v1/{{ backend }}/pki/ca/pem"
+    method: GET
+    return_content: yes
+  delegate_to: "{{ groups['control'][0] }}"
+  register: ca_cert
+
+- name: "Save CA to anchors folder"
+  copy:
+    content: "{{ ca_cert.content }}"
+    dest: "/etc/pki/ca-trust/source/anchors/{{ backend }}.pem"
+  register: anchors_copy
+
+- name: "Regenerate CAs"
+  when: anchors_copy.changed|bool
+  shell: update-ca-trust

--- a/docker-image/scripts/setup/01_env.sh
+++ b/docker-image/scripts/setup/01_env.sh
@@ -2,16 +2,16 @@
 sudo ln -sfT ${PROJECT_ENVIRONMENT_FILES_PATH}/inventory /etc/ansible/hosts
 
 # get hosts out of inventory
-hosts="$(cat inventory | grep ansible_ssh_host | cut -d" " -f1-2 | sed "s/ansible_ssh_host=//g")"
+hosts="$(cat inventory | grep ansible_ssh_host | sed -r 's/^([a-z0-9\._-]+).*ansible_ssh_host="([^"]+)".*/\1 \2/gi')"
 hostvars="$(ANSIBLE_STDOUT_CALLBACK=json ansible-playbook /dawn/ansible/dump_facts.yml)"
 
-# get the user's domain
-
-# set DOCKER_HOST
-export EDGE_NODE="$(echo ${hosts} | grep edge | head -n1 | cut -d " " -f2)"
-export CONTROL_NODE="$(echo ${hosts} | grep control | head -n1 | cut -d " " -f2)"
+# fetch domain names
 export LOCAL_DOMAIN="$(echo ${hostvars} | jq -r '[..|.local_domain_name?]|map(select(.))|unique[0]')"
 export LOCAL_DOMAIN_DC="$(echo ${hostvars} | jq -r '[..|.local_domain_dc?]|map(select(.))|unique[0]')"
+
+# set DOCKER_HOST
+export EDGE_NODE="$(echo "${hosts}" | grep edge | head -n1 | cut -d " " -f2)"
+export CONTROL_NODE="$(echo "${hosts}" | grep control | head -n1 | cut -d " " -f2)"
 
 # Set the PS1
 export PS1="${PROJECT_NAME} (${PROJECT_ENVIRONMENT}) \w $ "

--- a/docker-image/scripts/setup/40_vault.sh
+++ b/docker-image/scripts/setup/40_vault.sh
@@ -6,6 +6,16 @@
 
 VAULT_CERT_PATH="${HOME}/certs/vault"
 
+export VAULT_ADDR="https://${CONTROL_NODE}:8200"
+
+# If we can resolve the local domain properly, use that instead (usually local
+# dev envs won't be able to resolve unless the user changes his DNS)
+if
+    nslookup "vault.${LOCAL_DOMAIN}" 1>/dev/null 2>&1
+then
+    export VAULT_ADDR="http://vault.${LOCAL_DOMAIN}"
+fi
+
 # set VAULT environment variables, we first attempt to login using a generic
 # configuration, this configuration is created by the admin for each user and
 # should be installed manually on first setup. If this configuration does not
@@ -20,7 +30,6 @@ then
     VAULT_AUTH_BACKEND="$( jq -r .backend "${HOME}/.vault.conf" )"
     VAULT_AUTH_DATA="$( jq -cM .data "${HOME}/.vault.conf" )"
 
-    export VAULT_ADDR="https://${CONTROL_NODE}:8200"
     export VAULT_TOKEN="$( curl --connect-timeout 3 --cacert "${VAULT_CACERT}" -XPOST -sS "${VAULT_ADDR}/v1/auth/${VAULT_AUTH_BACKEND}/login" -d "${VAULT_AUTH_DATA}" | jq -r .auth.client_token )"
 elif
     [ -f "${HOME}/.vault.ansible.conf" ]
@@ -29,7 +38,6 @@ then
     export VAULT_CLIENT_CERT="${VAULT_CERT_PATH}/client.cert.pem"
     export VAULT_CLIENT_KEY="${VAULT_CERT_PATH}/client.key.pem"
 
-    export VAULT_ADDR="https://${CONTROL_NODE}:8200"
     export VAULT_TOKEN="$( curl --connect-timeout 3 --cacert "${VAULT_CACERT}" -XPOST -sS "${VAULT_ADDR}/v1/auth/approle/login" -d "$( cat ${HOME}/.vault.ansible.conf )" | jq -r .auth.client_token )"
 elif
     [ -f "${HOME}/.vault.root.conf" ]
@@ -38,7 +46,6 @@ then
     export VAULT_CLIENT_CERT="${VAULT_CERT_PATH}/client.cert.pem"
     export VAULT_CLIENT_KEY="${VAULT_CERT_PATH}/client.key.pem"
 
-    export VAULT_ADDR="https://${CONTROL_NODE}:8200"
     export VAULT_TOKEN="$( jq -r '.root_token' /home/dawn/.vault.root.conf )"
 else
     cat <<- EOM

--- a/docker-image/scripts/setup/50_docker.sh
+++ b/docker-image/scripts/setup/50_docker.sh
@@ -4,12 +4,12 @@
 # from vault to allow the user to connect via TLS
 #
 
-export DOCKER_HOST="${CONTROL_NODE}:2375"
+export DOCKER_HOST="${EDGE_NODE}:2375"
 
 if
     [ ! -z "${VAULT_TOKEN}" ]
 then
-    export DOCKER_HOST="tcp://${CONTROL_NODE}:2376"
+    export DOCKER_HOST="tcp://${EDGE_NODE}:2376"
     export DOCKER_TLS_VERIFY=1
     export DOCKER_CERT_PATH="${HOME}/certs/docker"
 


### PR DESCRIPTION
Depends on #20 

* Make intermediate CAs available on all machines as part of the trust chain
* Add a Traefik consul entry for vault
* Change the docker image env to point to the edge nodes instead of control (since in most setups only the edges are exposed)