### PR TITLE
Moved grafana and prometheus to docker stack, added rsyslog role

### DIFF
--- a/docker-image/ansible/roles/grafana/defaults/main.yml
+++ b/docker-image/ansible/roles/grafana/defaults/main.yml
@@ -3,4 +3,6 @@ grafana_version: 4.2.0
 grafana_user: admin
 grafana_password: admin
 grafana_link_to_container: prometheus
+grafana_stack_file: /opt/dawn/grafana.yml
+grafana_stack: grafana
 ldap_server: "{{ group_ipv4.control[0] }}"

--- a/docker-image/ansible/roles/grafana/files/dashboard.json
+++ b/docker-image/ansible/roles/grafana/files/dashboard.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "4.1.1"
+      "version": "4.2.0"
     },
     {
       "type": "panel",
@@ -1163,7 +1163,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(docker_container_cpu_usage_in_usermode{host=~\"$node\"}[1m])",
+              "expr": "rate(docker_container_cpu_usage_in_usermode{host=~\"$node\",com_docker_stack_namespace=~\"$stack\"}[1m])",
               "intervalFactor": 2,
               "legendFormat": "{{container_name}} ({{host}})",
               "metric": "docker_container_cpu_usage_in_usermode",
@@ -1235,7 +1235,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "docker_container_cpu_usage_percent{host=~\"$node\"}",
+              "expr": "docker_container_cpu_usage_percent{host=~\"$node\",com_docker_stack_namespace=~\"$stack\"}",
               "intervalFactor": 2,
               "legendFormat": "{{container_name}} ({{host}})",
               "metric": "docker_container_cpu_usage_percent",
@@ -1307,7 +1307,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(docker_container_cpu_usage_in_kernelmode{host=~\"$node\"}[1m])",
+              "expr": "rate(docker_container_cpu_usage_in_kernelmode{host=~\"$node\",com_docker_stack_namespace=~\"$stack\"}[1m])",
               "intervalFactor": 2,
               "legendFormat": "{{container_name}} ({{host}})",
               "metric": "docker_container_cpu_usage_in_kernelmode",
@@ -1379,7 +1379,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "docker_container_mem_usage{host=~\"$node\"}",
+              "expr": "docker_container_mem_usage{host=~\"$node\",com_docker_stack_namespace=~\"$stack\"}",
               "intervalFactor": 2,
               "legendFormat": "{{container_name}} ({{host}})",
               "metric": "docker_container_mem_usage",
@@ -1451,7 +1451,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "docker_container_mem_cache{host=~\"$node\"}",
+              "expr": "docker_container_mem_cache{host=~\"$node\",com_docker_stack_namespace=~\"$stack\"}",
               "intervalFactor": 2,
               "legendFormat": "{{container_name}} ({{host}})",
               "metric": "docker_container_mem_cache",
@@ -1523,7 +1523,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(docker_container_mem_pgfault{host=~\"$node\"}[1m])",
+              "expr": "rate(docker_container_mem_pgfault{host=~\"$node\",com_docker_stack_namespace=~\"$stack\"}[1m])",
               "intervalFactor": 2,
               "legendFormat": "{{container_name}} ({{host}})",
               "metric": "docker_container_mem",
@@ -1595,7 +1595,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "docker_container_mem_rss{host=~\"$node\"}",
+              "expr": "docker_container_mem_rss{host=~\"$node\",com_docker_stack_namespace=~\"$stack\"}",
               "intervalFactor": 2,
               "legendFormat": "{{container_name}} ({{host}})",
               "metric": "",
@@ -1667,7 +1667,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(docker_container_blkio_io_serviced_recursive_total{host=~\"$node\"}[5m])",
+              "expr": "rate(docker_container_blkio_io_serviced_recursive_total{host=~\"$node\",com_docker_stack_namespace=~\"$stack\"}[5m])",
               "intervalFactor": 2,
               "legendFormat": "{{container_name}} ({{host}})",
               "metric": "docker_container_blkio_io_serviced_recursive_total",
@@ -1739,7 +1739,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "docker_container_blkio_io_queue_recursive_total{host=~\"$node\"}",
+              "expr": "docker_container_blkio_io_queue_recursive_total{host=~\"$node\",com_docker_stack_namespace=~\"$stack\"}",
               "intervalFactor": 2,
               "legendFormat": "{{container_name}} ({{host}})",
               "metric": "docker_container_blkio_io_queue_recursive_total",
@@ -1811,7 +1811,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "docker_container_blkio_io_wait_time_total{host=~\"$node\"}",
+              "expr": "docker_container_blkio_io_wait_time_total{host=~\"$node\",com_docker_stack_namespace=~\"$stack\"}",
               "intervalFactor": 2,
               "legendFormat": "{{container_name}} ({{host}})",
               "metric": "docker_container_blkio_io_wait_time_total",
@@ -3050,6 +3050,26 @@
         "tagsQuery": "",
         "type": "query",
         "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": "prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Stack",
+        "multi": true,
+        "name": "stack",
+        "options": [],
+        "query": "label_values(com_docker_stack_namespace)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
@@ -3084,5 +3104,5 @@
   },
   "timezone": "browser",
   "title": "Hardware and Docker stats",
-  "version": 6
+  "version": 1
 }

--- a/docker-image/ansible/roles/grafana/meta/main.yml
+++ b/docker-image/ansible/roles/grafana/meta/main.yml
@@ -1,5 +1,0 @@
-dependencies:
-  - role: traefik-expose
-    service_name: grafana
-    service_port: 3000
-    service_ip: "{{ group_ipv4.monitor[0] }}"

--- a/docker-image/ansible/roles/grafana/tasks/main.yml
+++ b/docker-image/ansible/roles/grafana/tasks/main.yml
@@ -16,33 +16,22 @@
     - files
     - grafana
 
-- name: "Start Grafana on monitoring nodes"
-  docker_container:
-    # setup elastic search for log storage from remote fluentd instances
-    name: grafana
-    image: "{{ grafana_image}}:{{ grafana_version }}"
-    restart_policy: unless-stopped
-    env:
-      GF_SECURITY_ADMIN_USER: "{{ grafana_user }}"
-      GF_SECURITY_ADMIN_PASSWORD: "{{ grafana_password }}"
-    links:
-      - "{{ grafana_link_to_container }}"
-    published_ports:
-      - "3000:3000"
-    volumes:
-      # Configuration
-      - "/etc/grafana.ini:/etc/grafana/grafana.ini"
-      - "/etc/grafana-ldap.toml:/etc/grafana/ldap.toml"
-      - "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/ssl/certs/ca-certificates.crt:ro"
-      # Data Volumes
-      - "grafana:/var/lib/grafana"
+- name: "Create grafana stack file"
+  template:
+    dest: "{{ grafana_stack_file }}"
+    src: "grafana_stack.yml.j2"
+  register: grafana_stack_file_status
+
+- name: "Start grafana on the cluster"
+  when: grafana_stack_file_status.changed|bool
+  shell: "docker stack deploy -c '{{ grafana_stack_file }}' {{ grafana_stack }}"
   tags:
     - docker
     - grafana
 
 - name: "Build internal grafana URL"
   set_fact:
-    grafana_url: "http://{{ group_ipv4.monitor[0] }}:3000"
+    grafana_url: "http://grafana.{{ local_domain_name }}"
   tags:
     - grafana
 
@@ -69,7 +58,7 @@
     body:
       name: prometheus
       type: prometheus
-      url: http://prometheus:9090
+      url: http://prometheus_server:9090
       access: proxy
       basicAuth: false
     force_basic_auth: yes

--- a/docker-image/ansible/roles/grafana/templates/grafana_stack.yml.j2
+++ b/docker-image/ansible/roles/grafana/templates/grafana_stack.yml.j2
@@ -1,0 +1,41 @@
+version: "3"
+networks:
+  net:
+    driver: overlay
+  prometheus:
+    external:
+      name: prometheus_net
+  traefik:
+    external:
+      name: traefik_net
+volumes:
+  grafana:
+services:
+  app:
+    image: {{ grafana_image}}:{{ grafana_version }}
+    networks:
+      - net
+      - prometheus
+      - traefik
+    environment:
+      GF_SECURITY_ADMIN_USER: "{{ grafana_user }}"
+      GF_SECURITY_ADMIN_PASSWORD: "{{ grafana_password }}"
+    volumes:
+      # Configuration
+      - "/etc/grafana.ini:/etc/grafana/grafana.ini"
+      - "/etc/grafana-ldap.toml:/etc/grafana/ldap.toml"
+      - "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/ssl/certs/ca-certificates.crt:ro"
+      # Data Volumes
+      - "grafana:/var/lib/grafana"
+    deploy:
+      mode: global
+      restart_policy:
+        condition: on-failure
+      placement:
+        constraints:
+          - engine.labels.dawn.node.type == control
+      labels:
+        traefik.port: 3000
+        traefik.frontend.rule: "Host:grafana.{{ local_domain_name }}"
+        traefik.backend.loadbalancer.sticky: "true"
+        traefik.docker.network: traefik_net

--- a/docker-image/ansible/roles/prometheus/defaults/main.yml
+++ b/docker-image/ansible/roles/prometheus/defaults/main.yml
@@ -1,5 +1,7 @@
 prometheus_image: prom/prometheus
 prometheus_version: v1.6.1
+prometheus_stack_file: /opt/dawn/prometheus.yml
+prometheus_stack: prometheus
 
 consul_client_key_file: /etc/ssl/certs/consul/client.key.pem
 consul_client_cert_file: /etc/ssl/certs/consul/client.cert.pem

--- a/docker-image/ansible/roles/prometheus/tasks/main.yml
+++ b/docker-image/ansible/roles/prometheus/tasks/main.yml
@@ -4,17 +4,12 @@
     dest: /etc/prometheus.yml
     mode: 0644
 
-- name: "Start Prometheus on monitoring nodes"
-  docker_container:
-    name: prometheus
-    image: "{{ prometheus_image }}:{{ prometheus_version }}"
-    restart_policy: unless-stopped
-    volumes:
-      # Configuration
-      - "/etc/prometheus.yml:/etc/prometheus/prometheus.yml"
-      - "{{ consul_client_ca_file }}:/etc/ssl/certs/consul/ca.pem:ro"
-      - "{{ consul_client_cert_file }}:/etc/ssl/certs/consul/cert.pem:ro"
-      - "{{ consul_client_key_file }}:/etc/ssl/certs/consul/key.pem:ro"
-      # Data Volumes
-      - "prometheus:/prometheus"
+- name: "Create prometheus stack file"
+  template:
+    dest: "{{ prometheus_stack_file }}"
+    src: "prometheus_stack.yml.j2"
+  register: prometheus_stack_file_status
 
+- name: "Start prometheus on the cluster"
+  when: prometheus_stack_file_status.changed|bool
+  shell: "docker stack deploy -c '{{ prometheus_stack_file }}' {{ prometheus_stack }}"

--- a/docker-image/ansible/roles/prometheus/templates/prometheus_stack.yml.j2
+++ b/docker-image/ansible/roles/prometheus/templates/prometheus_stack.yml.j2
@@ -1,0 +1,35 @@
+version: "3"
+networks:
+  net:
+    driver: overlay
+  traefik:
+    external:
+      name: traefik_net
+volumes:
+  prometheus:
+services:
+  server:
+    image: {{ prometheus_image }}:{{ prometheus_version }}
+    networks:
+      - net
+      - traefik
+    volumes:
+      # Configuration
+      - "/etc/prometheus.yml:/etc/prometheus/prometheus.yml"
+      - "{{ consul_client_ca_file }}:/etc/ssl/certs/consul/ca.pem:ro"
+      - "{{ consul_client_cert_file }}:/etc/ssl/certs/consul/cert.pem:ro"
+      - "{{ consul_client_key_file }}:/etc/ssl/certs/consul/key.pem:ro"
+      # Data Volumes
+      - "prometheus:/prometheus"
+      # Extra CAs from our architecture
+      - "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:/etc/ssl/certs/ca-certificates.crt:ro"
+    deploy:
+      mode: global
+      placement:
+        constraints:
+          - engine.labels.dawn.node.type == control
+      labels:
+        traefik.port: 9090
+        traefik.frontend.rule: "Host:prometheus.{{ local_domain_name }}"
+        traefik.backend.loadbalancer.sticky: "true"
+        traefik.docker.network: traefik_net

--- a/docker-image/ansible/roles/rsyslog/defaults/main.yml
+++ b/docker-image/ansible/roles/rsyslog/defaults/main.yml
@@ -1,0 +1,2 @@
+rsyslog_target: "{{ group_ipv4.monitor[0] }}:1514"
+rsyslog_json: true

--- a/docker-image/ansible/roles/rsyslog/handlers/main.yml
+++ b/docker-image/ansible/roles/rsyslog/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: "Restart rsyslog"
+  service:
+    name: rsyslog
+    state: restarted
+

--- a/docker-image/ansible/roles/rsyslog/tasks/main.yml
+++ b/docker-image/ansible/roles/rsyslog/tasks/main.yml
@@ -1,0 +1,6 @@
+- name: "Install rsyslog config"
+  template:
+    src: "rsyslog.conf.j2"
+    dest: /etc/rsyslog.conf
+    mode: 0644
+  notify: "Restart rsyslog"

--- a/docker-image/ansible/roles/rsyslog/templates/rsyslog.conf.j2
+++ b/docker-image/ansible/roles/rsyslog/templates/rsyslog.conf.j2
@@ -1,0 +1,95 @@
+# rsyslog configuration file
+
+# For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html
+# If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
+
+#### MODULES ####
+
+# The imjournal module bellow is now used as a message source instead of imuxsock.
+$ModLoad imuxsock # provides support for local system logging (e.g. via logger command)
+$ModLoad imjournal # provides access to the systemd journal
+#$ModLoad imklog # reads kernel messages (the same are read from journald)
+#$ModLoad immark  # provides --MARK-- message capability
+
+# Provides UDP syslog reception
+#$ModLoad imudp
+#$UDPServerRun 514
+
+# Provides TCP syslog reception
+#$ModLoad imtcp
+#$InputTCPServerRun 514
+
+
+#### GLOBAL DIRECTIVES ####
+
+# Where to place auxiliary files
+$WorkDirectory /var/lib/rsyslog
+
+# Use default timestamp format
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+# File syncing capability is disabled by default. This feature is usually not required,
+# not useful and an extreme performance hit
+#$ActionFileEnableSync on
+
+# Include all config files in /etc/rsyslog.d/
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+# Turn off message reception via local log socket;
+# local messages are retrieved through imjournal now.
+$OmitLocalLogging on
+
+# File to store the position in the journal
+$IMJournalStateFile imjournal.state
+
+
+#### RULES ####
+
+# Log all kernel messages to the console.
+# Logging much else clutters up the screen.
+#kern.*                                                 /dev/console
+
+# Log anything (except mail) of level info or higher.
+# Don't log private authentication messages!
+*.info;mail.none;authpriv.none;cron.none                /var/log/messages
+
+# The authpriv file has restricted access.
+authpriv.*                                              /var/log/secure
+
+# Log all the mail messages in one place.
+mail.*                                                  -/var/log/maillog
+
+# Log cron stuff
+cron.*                                                  /var/log/cron
+
+# Everybody gets emergency messages
+*.emerg                                                 :omusrmsg:*
+
+# Save news errors of level crit and higher in a special file.
+uucp,news.crit                                          /var/log/spooler
+
+# Save boot messages also to boot.log
+local7.*                                                /var/log/boot.log
+
+
+# ### begin forwarding rule ###
+# The statement between the begin ... end define a SINGLE forwarding
+# rule. They belong together, do NOT split them. If you create multiple
+# forwarding rules, duplicate the whole block!
+# Remote Logging (we use TCP for reliable delivery)
+#
+# An on-disk queue is created for this action. If the remote host is
+# down, messages are spooled to disk and sent when it is up again.
+#$ActionQueueFileName fwdRule1 # unique name prefix for spool files
+#$ActionQueueMaxDiskSpace 1g   # 1gb space limit (use as much as possible)
+#$ActionQueueSaveOnShutdown on # save messages to disk on shutdown
+#$ActionQueueType LinkedList   # run asynchronously
+#$ActionResumeRetryCount -1    # infinite retries if host is down
+# remote host is: name/ip:port, e.g. 192.168.0.1:514, port optional
+{% if rsyslog_json|bool %}
+template(name="JSONLog" type="list") { property(name="$!all-json") }
+*.* @{{ rsyslog_target }};JSONLog
+{% else %}
+*.* @{{ rsyslog_target }}
+{% endif %}
+# ### end of the forwarding rule ###

--- a/docker-image/templates/aws/ansible/playbook.yml
+++ b/docker-image/templates/aws/ansible/playbook.yml
@@ -19,6 +19,7 @@
     - docker-gc
     - telegraf
     - https
+    - rsyslog
 
 # Setup vault, ldap and swarm on the control nodes
 - hosts: control

--- a/docker-image/templates/local/ansible/playbook.yml
+++ b/docker-image/templates/local/ansible/playbook.yml
@@ -19,6 +19,7 @@
     - docker-gc
     - telegraf
     - https
+    - rsyslog
 
 # Setup vault, ldap and swarm on the control nodes
 - hosts: control


### PR DESCRIPTION
When I removed fluentd I delete the rsyslog task, oups.
This also moves grafana and prometheus to docker services, which allows prometheus to pull data from containers if they expose metrics themselves.