### PR TITLE
[WIP] Upgraded ansible, terraform, vault and docker

### DIFF
--- a/buildconfig.yml
+++ b/buildconfig.yml
@@ -88,7 +88,7 @@ image:
 
   # The version to use for each software installed in the image
   software_versions:
-    ansible:   "2.2.3.0"
-    terraform: "0.9.9"
-    vault:     "0.7.3"
-    docker:    "17.05.0-ce"
+    ansible:   "2.3.2.0"
+    terraform: "0.10.4"
+    vault:     "0.8.2"
+    docker:    "17.06.2-ce"

--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -6,10 +6,10 @@ ARG root_folder=/dawn
 ARG shell_user=dawn
 ARG configuration_folder=dawn
 ARG configuration_filename=dawn.yml
-ARG ansible_version=2.2.3.0
-ARG terraform_version=0.9.9
-ARG vault_version=0.7.3
-ARG docker_version=17.05.0-ce
+ARG ansible_version=2.3.2.0
+ARG terraform_version=0.10.4
+ARG vault_version=0.8.2
+ARG docker_version=17.06.2-ce
 
 # Update the package list
 RUN apk update && apk upgrade
@@ -68,7 +68,7 @@ RUN wget -q https://releases.hashicorp.com/vault/${vault_version}/vault_${vault_
     && rm /tmp/vault.zip
 
 # Install Docker binaries
-RUN wget -q https://get.docker.com/builds/Linux/x86_64/docker-${docker_version}.tgz \
+RUN wget -q https://download.docker.com/linux/static/stable/x86_64/docker-${docker_version}.tgz \
       -O /tmp/docker.tgz \
     && cd /tmp \
     && tar -zxf docker.tgz \

--- a/docker-image/ansible/requirements.yml
+++ b/docker-image/ansible/requirements.yml
@@ -21,7 +21,7 @@
 - name: AerisCloud.rsyslog
   version: v1.1.0
 - name: AerisCloud.vault
-  version: v1.0.2
+  version: v1.1.0
 
 # external roles
 - name: williamyeh.fluentd

--- a/docker-image/ansible/roles/bootstrap-security/tasks/root_ca.yml
+++ b/docker-image/ansible/roles/bootstrap-security/tasks/root_ca.yml
@@ -15,7 +15,8 @@
 # We need to do the tuning manually since the lib doesn't provide the method for it
 - name: "Tune root CA TTL"
   uri:
-    HEADER_X-Vault-Token: "{{ vault_vars.root_token }}"
+    headers:
+      X-Vault-Token: "{{ vault_vars.root_token }}"
     url: "{{ vault_addr }}/v1/sys/mounts/pki/tune"
     method: POST
     body_format: json

--- a/docker-image/ansible/roles/common/README.md
+++ b/docker-image/ansible/roles/common/README.md
@@ -6,7 +6,9 @@ Does tasks common to all systems:
 * Set the hostname to match the inventory name
 * Add all hosts in the cluster to /etc/hosts
 * When running on CentOS enable EPEL
+* Allows upgrading the system
 
 ## Variables
 
 * `timezone = UTC`: Set the timezone of the machine
+* `system_upgrade`: When set to 1, will upgrade all packages on the system

--- a/docker-image/ansible/roles/common/tasks/centos.yml
+++ b/docker-image/ansible/roles/common/tasks/centos.yml
@@ -1,7 +1,13 @@
 - name: "Enable EPEL repo"
-  become: true
   yum:
     name: epel-release
     state: latest
   tags:
     - common
+
+- name: "Upgrade all packages"
+  when: system_upgrade is defined and system_upgrade|bool
+  yum:
+    update_cache: yes
+    name: '*'
+    state: latest

--- a/docker-image/ansible/roles/common/tasks/main.yml
+++ b/docker-image/ansible/roles/common/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: "Set the timezone to {{ timezone }}"
-  become: true
   file:
     src: "/usr/share/zoneinfo/{{ timezone }}"
     dest: /etc/localtime
@@ -13,7 +12,6 @@
     - timezone
 
 - name: "Set the hostname"
-  become: true
   copy:
     dest: /etc/hostname
     content: "{{ inventory_hostname }}"
@@ -25,7 +23,6 @@
     - common
 
 - name: "Configure hosts file"
-  become: true
   template:
     src: hosts.j2
     dest: /etc/hosts

--- a/docker-image/ansible/roles/generate-tls/tasks/main.yml
+++ b/docker-image/ansible/roles/generate-tls/tasks/main.yml
@@ -24,7 +24,8 @@
 # Generate the server certificates
 - name: "Generate certificates"
   uri:
-    HEADER_X-Vault-Token: "{{ vault_token }}"
+    headers:
+      X-Vault-Token: "{{ vault_token }}"
     url: "http://127.0.0.1:8200/v1/{{ pki.backend }}/pki/issue/{{ pki.role }}"
     method: POST
     body_format: json

--- a/docker-image/ansible/roles/register-ca/tasks/register_ca.yml
+++ b/docker-image/ansible/roles/register-ca/tasks/register_ca.yml
@@ -1,6 +1,7 @@
 - name: "Fetch remote CA"
   uri:
-    HEADER_X-Vault-Token: "{{ vault_token }}"
+    headers:
+      X-Vault-Token: "{{ vault_token }}"
     url: "http://127.0.0.1:8200/v1/{{ backend }}/pki/ca/pem"
     method: GET
     return_content: yes
@@ -13,9 +14,9 @@
     dest: "/etc/pki/ca-trust/source/anchors/{{ backend }}.pem"
   register: anchors_copy
   delegate_to: "{{ target_host }}"
-  delegate_facts: true
+  #delegate_facts: true
 
 - name: "Regenerate CAs ({{ target_host }})"
-  when: hostvars[target_host].anchors_copy.changed|bool
+  when: anchors_copy.changed|bool
   shell: update-ca-trust
   delegate_to: "{{ target_host }}"

--- a/docker-image/ansible/roles/vault-setup-ca/tasks/main.yml
+++ b/docker-image/ansible/roles/vault-setup-ca/tasks/main.yml
@@ -16,9 +16,10 @@
   # We need to do the tuning manually since the lib doesn't provide the method for it
   - name: "Tune {{ backend_name }} CA TTL"
     uri:
-      HEADER_X-Vault-Token: "{{ vault_token }}"
       url: "{{ vault_addr }}/v1/sys/mounts/{{ backend_name }}/pki/tune"
       method: POST
+      headers:
+        X-Vault-Token: "{{ vault_token }}"
       body_format: json
       body: "{\"max_lease_ttl\":\"{{ vault_intermediate_ca_ttl }}\"}"
       status_code: 204


### PR DESCRIPTION
* Ansible upgraded to 2.3.2.0, fixed deprecation warnings in playbooks
* Docker CLI updated to 17.06.2-ce, using new download mirror
* Terraform CLI updated to 0.10.4
* Vault CLI updated to 0.8.2
* Vault role updated to install 0.8.2 on servers
* Added new environment variable allowing users to upgrade their system
* Removed useless tags
* Removed useless become
* Stopped using delegate_facts since it seems to be broken