### PR TITLE
local: gw is now in config

### DIFF
--- a/docker-image/templates/local/Vagrantfile
+++ b/docker-image/templates/local/Vagrantfile
@@ -151,7 +151,7 @@ Vagrant.configure("2") do |config|
           echo "ONBOOT=\"yes\"" >> $file
           echo "IPADDR=\"#{instance_info['ip']}\"" >> $file
           echo "NETMASK=\"255.255.255.0\"" >> $file
-          echo "GATEWAY=\"172.24.0.1\"" >> $file
+          echo "GATEWAY=\"#{configuration['gateway']}\"" >> $file
           echo "DNS1=\"8.8.8.8\"" >> $file
 
           echo ""

--- a/docker-image/templates/local/vagrant/instances.yml
+++ b/docker-image/templates/local/vagrant/instances.yml
@@ -52,6 +52,10 @@ base: &base
     ? swarm
     ? consul
 
+# The network gateway to use/set up. This should match with the network
+# used by the instances below
+gateway: "172.24.0.1"
+
 # this is our list of instances, usually you will want at least one control, one
 # edge and one worker, though you should be able to merge them by specifying the
 # right groups


### PR DESCRIPTION
When changing the IP of the machines (example: when the network is
already being used for something else), we need to be able to change
the IP gateway from the same file we will be changing the IP of the
instances.