### PR TITLE
Add custom DNS support to the dawn configuration

### DIFF
--- a/docs/includes/_deploy.md.erb
+++ b/docs/includes/_deploy.md.erb
@@ -182,3 +182,19 @@ running your container.
 
 You can use this to declare a service on the local consul agent or find out the
 IP of the host machine for service discovery.
+
+Finally when using a custom domain for example in a local environment running in
+vagrant it might be useful to tell the dawn binary to use the DNS installed on
+your control node. To do so you can edit your dawn configuration like so:
+
+```yaml
+project_name: my_project
+base_image: <%= build_config['image']['organization'] %>/<%= build_config['image']['name'] %>:1.0.0
+image: my_org/my_project
+
+environments:
+  local:
+    dns:
+    - 172.24.0.50 # your control node's IP
+    - 192.168.1.1 # your normal DNS for fallback
+```

--- a/docs/includes/_introduction.md.erb
+++ b/docs/includes/_introduction.md.erb
@@ -52,16 +52,17 @@ to simply use the ones you already know.
 
 ```yaml
 project_name: hello-world
-image: 1.0.0 # This will be used as the default version
+base_image: <%= build_config['image']['organization'] %>/<%= build_config['image']['name'] %>:1.0.0 # The default version to use
+image: project_name # This will create a custom image for your project, tag is the environment
 
 environment:
     # Bump the image version number for the staging environment
     staging:
-        image: 1.0.1
+        base_image: <%= build_config['image']['organization'] %>/<%= build_config['image']['name'] %>:1.0.1
 
     # Maintain an experimental environment using a custom local container
     experimental:
-        image: stelcheck/custom:latest
+        base_image: stelcheck/custom:latest
 ```
 
 When creating a new environment, we hard-code the version of the local Docker image


### PR DESCRIPTION
When using a custom domain for example in a local environment running in vagrant it might be useful to tell the dawn binary to use the DNS installed on the control node in the container, this allows us to do exactly that.

Also took the opportunity to fix an outdated piece of documentation.