### PR TITLE
windows fixes, dockerignore

### DIFF
--- a/docker-image/templates/local/Vagrantfile
+++ b/docker-image/templates/local/Vagrantfile
@@ -133,7 +133,13 @@ Vagrant.configure("2") do |config|
 
       # we don't need this (also causes issues with centos 7 image)
       instance.vm.synced_folder ".", "/vagrant", disabled: true
-      instance.vm.hostname = instance_name
+
+      # This has been disabled for some environments because
+      # vagrant will fail upon trying to reset the hostname on the remote machine
+      # (more specifically, when trying to restart the network service)
+      if !isWindows()
+        instance.vm.hostname = instance_name
+      end
 
       # vagrant doesn't currently support private networking on Hyper-V;
       # the workaround is to manually set up the networking

--- a/docker-image/templates/local/vagrant-up.ps1
+++ b/docker-image/templates/local/vagrant-up.ps1
@@ -1,5 +1,13 @@
+param(
+  [Switch] $ResetNetwork = $false
+)
+
 # Make sure network is set up
-.\vagrant\networking.ps1
+if ($ResetNetwork) {
+  .\vagrant\networking.ps1 -Reset
+} else {
+  .\vagrant\networking.ps1
+}
 
 # We try to find sh and ssh on the local system;
 # we essentially check to see if git or cygwin is
@@ -23,4 +31,4 @@ $index = $switch.LineNumber
 
 # This option is just to automate
 # the virtual switch selection
-sh -c "yes $index | vagrant up"
+sh -c "yes ${index} | vagrant up"

--- a/docker-image/templates/local/vagrant/instances.yml
+++ b/docker-image/templates/local/vagrant/instances.yml
@@ -10,7 +10,7 @@
 # for all other supported platforms
 images:
   virtualbox: "centos/7"
-  hyperv: "bluefedora/hyperv-alpha-centos7"
+  hyperv: "centos/7"
 
 user: vagrant
 


### PR DESCRIPTION
  * Fixes to get the project to run properly on windows
  * Windows: add a flag to reset the private network when needed
  * Windows: use the same image as on other platforms (centos/7)
  * .dockerignore file template (to ignore .vagrant folder if present)