### PR TITLE
 run.sh was not being called, aws run script bug

### DIFF
--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -121,6 +121,16 @@ RUN echo "${shell_user} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN sudo mkdir -p /var/lib/teleport \
 	&& sudo chown ${shell_user} /var/lib/teleport
 
+# inputrc
+RUN echo -en '# mappings for Ctrl-left-arrow and Ctrl-right-arrow for word moving \n \
+"\\e[1;5C": forward-word \n \
+"\\e[1;5D": backward-word \n \
+"\\e[5C": forward-word \n \
+"\\e[5D": backward-word \n \
+"\\e\\e[C": forward-word \n \
+"\\e\\e[D": backward-word \n \
+' > /etc/inputrc
+
 # Volumes. The first one is where the project files will be found;
 # The second one will be mounted from
 # %APP_DATA%/projects/[project_name]/[environment_name]

--- a/docker-image/scripts/setup_environment.py
+++ b/docker-image/scripts/setup_environment.py
@@ -9,6 +9,13 @@ from pylib.ansible import AnsibleEnvironment
 from pylib.docker import setup_docker
 from pylib.vault import setup_vault
 
+def append_run_script(templates):
+    # run run.sh if it exists
+    run_file = os.path.join(
+        os.environ.get('PROJECT_ENVIRONMENT_FILES_PATH'), 'run.sh')
+    if os.path.exists(run_file):
+        templates.append(run_template)
+
 if __name__ == "__main__":
     env = AnsibleEnvironment()
 
@@ -36,11 +43,7 @@ if __name__ == "__main__":
     if os.environ.get('COMMAND').startswith('bash'):
         templates.append(motd_template)
 
-    # run run.sh if it exists
-    run_file = os.path.join(
-        os.environ.get('PROJECT_ENVIRONMENT_FILES_PATH'), 'run.sh')
-    if os.path.exists(run_file):
-        templates.append(run_template)
+    append_run_script(templates)
 
     # print all the templates
     try:
@@ -51,10 +54,16 @@ if __name__ == "__main__":
         print('''
 cat <<- EOM
 
-It seems your inventory is empty, if using the bare template make sure to run
-vagrant before starting your container to start the VMs and provision your
-inventory file.
+No inventory file was found in the project folder, either run the provisioning
+tool associated with your environment (vagrant, terraform, etc...) or write your
+own inventory (see the documentation for more details).
+
+Once the inventory file exists either logout/login or source ~/.bash/profile to
+load the environment variables associated with your project.
 
 EOM
 ''')
+        templates = []
+        append_run_script(templates)
+        print(env.template(*templates))
         sys.exit(0)

--- a/docker-image/scripts/user_bash_profile.sh
+++ b/docker-image/scripts/user_bash_profile.sh
@@ -8,27 +8,13 @@
 
 SCRIPTS_PATH="${ROOT_FOLDER}/scripts/setup"
 
-if
-    [ -f ./inventory ]
-then
-    # Link the project inventory and group vars to the ansible folder
-    sudo ln -sfT ${PROJECT_ENVIRONMENT_FILES_PATH}/inventory /etc/ansible/hosts
-    sudo ln -sfT ${PROJECT_ENVIRONMENT_FILES_PATH}/ansible/group_vars /etc/ansible/group_vars
+# Link the project inventory and group vars to the ansible folder
+sudo ln -sfT ${PROJECT_ENVIRONMENT_FILES_PATH}/inventory /etc/ansible/hosts
+sudo ln -sf ${PROJECT_ENVIRONMENT_FILES_PATH}/ansible/group_vars /etc/ansible/group_vars
 
-    # Setup the user environment
-    eval "$( "${ROOT_FOLDER}/scripts/setup_environment.py" )"
-else
-    cat <<-EOM
+# Setup the user environment
+eval "$( "${ROOT_FOLDER}/scripts/setup_environment.py" )"
 
-No inventory file was found in the project folder, either run the provisioning
-tool associated with your environment (vagrant, terraform, etc...) or write your
-own inventory (see the documentation for more details).
-
-Once the inventory file exists either logout/login or source ~/.bash/profile to
-load the environment variables associated with your project.
-
-EOM
-fi
 
 # Allow the user to override what they want by running .bashrc
 [[ -f ~/.bashrc ]] && . ~/.bashrc

--- a/docker-image/templates/aws/run.sh
+++ b/docker-image/templates/aws/run.sh
@@ -43,14 +43,14 @@ echo ""
 
 # Warn user if deploy key is not found
 if
-    [ ! -f /home/${SHELL_USER_HOMEDIR}/.ssh/deploy ]
+    [ ! -f /home/${SHELL_USER}/.ssh/deploy ]
 then
     echo "** Warning ** private deploy key not found (/home/${SHELL_USER_HOMEDIR}/.ssh/deploy)"
     echo "** Warning ** While you may still be able to start or stop new machines"
     echo "** Warning ** using Terraform, you will not be able to provision them"
     echo "** Warning ** using Ansible. Request the private key, and put it here:"
     echo "** Warning **"
-    echo "** Warning ** /home/${SHELL_USER_HOMEDIR}/.ssh/deploy"
+    echo "** Warning ** /home/${SHELL_USER}/.ssh/deploy"
     echo "** Warning **"
     echo ""
 fi


### PR DESCRIPTION
${SHELL_USER_HOMEDIR} -> /${SHELL_USER} in aws' run.sh

removed superfluous warning from user_bash_profile

always call run.sh

Requires #53 
