### PR TITLE
Whitelist, config and upgrade

### DIFF
--- a/docker-image/ansible/requirements.yml
+++ b/docker-image/ansible/requirements.yml
@@ -13,7 +13,7 @@
 - name: AerisCloud.consul-service
   version: v1.0.0
 - name: AerisCloud.docker
-  version: v1.2.1
+  version: v1.3.0
 - name: AerisCloud.dnsmasq-template
   version: v1.0.0
 - name: AerisCloud.rsyslog

--- a/docker-image/ansible/roles/consul/tasks/main.yml
+++ b/docker-image/ansible/roles/consul/tasks/main.yml
@@ -63,6 +63,7 @@
         cert: "{{ consul_client_cert_file }}"
         key: "{{ consul_client_key_file }}"
         ca: "{{ consul_client_ca_file }}"
+        permissions: 664
       # TLS request data
       request_data:
         common_name: "client.consul.{{ local_domain_name }}"

--- a/docker-image/ansible/roles/elasticsearch/defaults/main.yml
+++ b/docker-image/ansible/roles/elasticsearch/defaults/main.yml
@@ -1,5 +1,6 @@
 elasticsearch_image: docker.elastic.co/elasticsearch/elasticsearch
-elasticsearch_version: 5.6.9
+elasticsearch_version: 6.2.4
 elasticsearch_java_opts: "-Xms512m -Xmx512m"
 logstash_image: docker.elastic.co/logstash/logstash
 kibana_image: docker.elastic.co/kibana/kibana
+kibana_whitelist: 0.0.0.0/0

--- a/docker-image/ansible/roles/elasticsearch/meta/main.yml
+++ b/docker-image/ansible/roles/elasticsearch/meta/main.yml
@@ -3,3 +3,4 @@ dependencies:
     service_name: kibana
     service_port: 5601
     service_ip: "{{ group_ipv4.monitor[0] }}"
+    service_whitelist: "{{ kibana_whitelist }}"

--- a/docker-image/ansible/roles/elasticsearch/tasks/main.yml
+++ b/docker-image/ansible/roles/elasticsearch/tasks/main.yml
@@ -33,7 +33,7 @@
       transport.host: 0.0.0.0
       discovery.zen.minimum_master_nodes: 1
       node.name: "{{ inventory_hostname }}"
-      xpack.security.enabled: 0
+      xpack.security.enabled: "false"
     restart_policy: unless-stopped
     published_ports:
       - "9200:9200"

--- a/docker-image/ansible/roles/elasticsearch/templates/rsyslog.conf.j2
+++ b/docker-image/ansible/roles/elasticsearch/templates/rsyslog.conf.j2
@@ -33,7 +33,7 @@ filter {
 
 			ruby {
 				code => "
-					if event.get('container_name').include? '_'
+					if event.get('container_name') and event.get('container_name').include? '_'
 						_stack_els = event.get('container_name')[/^([a-z0-9_-]+)/i, 0].split('_', 2)
 						event.set('docker_stack', _stack_els[0])
 						event.set('docker_service', _stack_els[1])

--- a/docker-image/ansible/roles/generate-tls/tasks/main.yml
+++ b/docker-image/ansible/roles/generate-tls/tasks/main.yml
@@ -42,7 +42,7 @@
   copy:
     content: "{{ certificates.json.data[item.key] }}"
     dest: "{{ item.file }}"
-    mode: 0660
+    mode: {{ pki.permissions | default(0600) }}
     owner: "{{ pki.owner|default(omit) }}"
     group: "{{ pki.group|default(omit) }}"
   notify: "{{ pki.notify|default(omit) }}"
@@ -61,7 +61,7 @@
   copy:
     content: "{{ certificates.json.data[item.key] }}"
     dest: "{{ item.file }}"
-    mode: 0660
+    mode: {{ pki.permissions | default(0600) }}
     owner: "{{ pki.owner|default(omit) }}"
     group: "{{ pki.group|default(omit) }}"
   notify: "{{ pki.notify|default(omit) }}"

--- a/docker-image/ansible/roles/grafana/defaults/main.yml
+++ b/docker-image/ansible/roles/grafana/defaults/main.yml
@@ -1,5 +1,6 @@
 grafana_image: grafana/grafana
 grafana_version: 5.1.0
+grafana_whitelist: 0.0.0.0/0
 grafana_user: admin
 grafana_password: admin
 grafana_link_to_container: prometheus

--- a/docker-image/ansible/roles/grafana/templates/grafana.ini.j2
+++ b/docker-image/ansible/roles/grafana/templates/grafana.ini.j2
@@ -268,7 +268,7 @@ allow_sign_up = false
 #################################### Auth LDAP ##########################
 [auth.ldap]
 enabled = true
-config_file = /etc/grafana/ldap.toml
+config_file = /etc/grafana-ldap.toml
 ;allow_sign_up = true
 
 #################################### SMTP / Emailing ##########################

--- a/docker-image/ansible/roles/grafana/templates/grafana_stack.yml.j2
+++ b/docker-image/ansible/roles/grafana/templates/grafana_stack.yml.j2
@@ -36,5 +36,6 @@ services:
       labels:
         traefik.port: 3000
         traefik.frontend.rule: "Host:grafana.{{ local_domain_name }}"
-        traefik.backend.loadbalancer.sticky: "true"
+        traefik.frontend.whitelist.sourceRange: "{{ grafana_whitelist }}"
+        traefik.backend.loadbalancer.stickiness: "true"
         traefik.docker.network: traefik_net

--- a/docker-image/ansible/roles/openldap/defaults/main.yml
+++ b/docker-image/ansible/roles/openldap/defaults/main.yml
@@ -15,4 +15,5 @@ openldap_image: osixia/openldap
 openldap_version: 1.1.8
 
 phpldapadmin_image: osixia/phpldapadmin
-phpldapadmin_version: 0.6.12
+phpldapadmin_version: 0.7.1
+phpldapadmin_whitelist: 0.0.0.0/0

--- a/docker-image/ansible/roles/openldap/meta/main.yml
+++ b/docker-image/ansible/roles/openldap/meta/main.yml
@@ -7,6 +7,7 @@ dependencies:
     backend: ldap
   - role: traefik-expose
     service_name: ldap-admin
-    service_scheme: https
-    service_port: 6443
+    service_scheme: http
+    service_port: 18080
     service_ip: "{{ group_ipv4.control[0] }}"
+    service_whitelist: "{{ phpldapadmin_whitelist }}"

--- a/docker-image/ansible/roles/openldap/tasks/setup.yml
+++ b/docker-image/ansible/roles/openldap/tasks/setup.yml
@@ -60,15 +60,10 @@
     image: "{{ phpldapadmin_image }}:{{ phpldapadmin_version }}"
     restart_policy: always
     published_ports:
-      - "6443:443"
+      - "18080:80"
     links:
       - "openldap:ldap"
-    volumes:
-      - "{{ https_cert_file }}:/container/service/phpldapadmin/assets/apache2/certs/cert.pem:ro"
-      - "{{ https_key_file }}:/container/service/phpldapadmin/assets/apache2/certs/key.pem:ro"
-      - "{{ https_ca_file }}:/container/service/phpldapadmin/assets/apache2/certs/ca.pem:ro"
     env:
-      PHPLDAPADMIN_LDAP_HOSTS: ldap
-      PHPLDAPADMIN_HTTPS_CRT_FILENAME: cert.pem
-      PHPLDAPADMIN_HTTPS_KEY_FILENAME: key.pem
-      PHPLDAPADMIN_HTTPS_CA_CRT_FILENAME: ca.pem
+      PHPLDAPADMIN_LDAP_HOSTS: "ldap"
+      PHPLDAPADMIN_HTTPS: "false"
+      PHPLDAPADMIN_TRUST_PROXY_SSL: "true"

--- a/docker-image/ansible/roles/prometheus/templates/prometheus_stack.yml.j2
+++ b/docker-image/ansible/roles/prometheus/templates/prometheus_stack.yml.j2
@@ -30,5 +30,5 @@ services:
       labels:
         traefik.port: 9090
         traefik.frontend.rule: "Host:prometheus.{{ local_domain_name }}"
-        traefik.backend.loadbalancer.sticky: "true"
+        traefik.backend.loadbalancer.stickiness: "true"
         traefik.docker.network: traefik_net

--- a/docker-image/ansible/roles/registry/defaults/main.yml
+++ b/docker-image/ansible/roles/registry/defaults/main.yml
@@ -7,6 +7,7 @@ docker_auth_version: 1
 
 registry_image: registry
 registry_version: 2
+registry_whitelist: 0.0.0.0/0
 
 ldap_server: "{{ group_ipv4.control[0] }}"
 ldap_server_port: 389

--- a/docker-image/ansible/roles/registry/meta/main.yml
+++ b/docker-image/ansible/roles/registry/meta/main.yml
@@ -8,3 +8,4 @@ dependencies:
     service_port: 5001
     service_scheme: https
     service_ip: "{{ group_ipv4.control[0] }}"
+    service_whitelist: "{{ registry_whitelist }}"

--- a/docker-image/ansible/roles/swarm/README.md
+++ b/docker-image/ansible/roles/swarm/README.md
@@ -12,4 +12,5 @@ or `worker`.
 * `swarm_worker = "{{ inventory_hostname not in groups['control'] and inventory_hostname not in groups['edge'] }}"`
 * `swarm_remote_addrs = []`
 * `swarm_listen_addr = 0.0.0.0`
+* `swarm_listen_addr = 172.18.0.1/16`
 * `swarm_advertise_addr = "{{ private_ipv4 }}"`

--- a/docker-image/ansible/roles/swarm/defaults/main.yml
+++ b/docker-image/ansible/roles/swarm/defaults/main.yml
@@ -18,7 +18,10 @@ swarm_worker: "{{ inventory_hostname not in groups['control'] and inventory_host
 swarm_remote_addrs: []
 
 # on which (address|interface)[:port] the swarm should be listening
-swarm_listen_addr: 0.0.0.0
+swarm_listen_addr: "0.0.0.0"
 
 # advertise address, docker will try to find a decent default
 swarm_advertise_addr: "{{ private_ipv4 }}"
+
+# network range to use for swarm containers
+swarm_network: "172.18.0.1/16"

--- a/docker-image/ansible/roles/swarm/tasks/main.yml
+++ b/docker-image/ansible/roles/swarm/tasks/main.yml
@@ -1,5 +1,14 @@
 ---
-# tasks file for AerisCloud.swarm
+- name: "Create a custom network"
+  docker_network:
+    name: "docker_gwbridge"
+    driver_options:
+      com.docker.network.bridge.enable_icc: "false"
+      com.docker.network.bridge.enable_ip_masquerade: "true"
+      com.docker.network.bridge.name: "docker_gwbridge"
+    ipam_options:
+      subnet: "{{ swarm_network }}"
+
 - include: swarm_init.yml
   when: swarm_leader|bool
 

--- a/docker-image/ansible/roles/telegraf/tasks/main.yml
+++ b/docker-image/ansible/roles/telegraf/tasks/main.yml
@@ -13,7 +13,7 @@
           - endpoint = "unix:///var/run/docker.sock"
           - container_names = []
 
-- name: Give the Telegraf user access to docker
+- name: "Give the Telegraf user access to docker"
   user:
     name: telegraf
     groups: docker

--- a/docker-image/ansible/roles/teleport/defaults/main.yml
+++ b/docker-image/ansible/roles/teleport/defaults/main.yml
@@ -6,3 +6,6 @@ teleport_cert_file: /etc/ssl/certs/teleport/server.cert.pem
 teleport_key_file: /etc/ssl/certs/teleport/server.key.pem
 teleport_ca_file: /etc/ssl/certs/teleport/server.ca.pem
 teleport_server_cert_ttl: 8760h
+
+teleport_cluster_name: "dawn"
+teleport_whitelist: 0.0.0.0/0

--- a/docker-image/ansible/roles/teleport/meta/main.yml
+++ b/docker-image/ansible/roles/teleport/meta/main.yml
@@ -10,3 +10,4 @@ dependencies:
     service_scheme: https
     service_port: 3080
     service_ip: "{{ group_ipv4.control[0] }}"
+    service_whitelist: "{{ teleport_whitelist }}"

--- a/docker-image/ansible/roles/teleport/templates/teleport.yaml.j2
+++ b/docker-image/ansible/roles/teleport/templates/teleport.yaml.j2
@@ -82,7 +82,7 @@ auth_service:
     #
     # IMPORTANT: if you change cluster_name, it will invalidate all generated
     # certificates and keys (may need to wipe out /var/lib/teleport directory)
-    cluster_name: "wizcorp"
+    cluster_name: "{{ teleport_cluster_name }}"
 
 # This section configures the 'node service':
 ssh_service:

--- a/docker-image/ansible/roles/traefik-expose/tasks/main.yml
+++ b/docker-image/ansible/roles/traefik-expose/tasks/main.yml
@@ -7,10 +7,12 @@
   with_items:
     # kibana
     - key: "traefik/backends/{{ service_name }}/servers/{{ service_name }}/url"
-      value: "{{ service_scheme|default('http') }}://{{ service_ip|default(private_ipv4) }}:{{ service_port }}"
+      value: "{{ service_scheme | default('http') }}://{{ service_ip | default(private_ipv4) }}:{{ service_port }}"
     - key: "traefik/backends/{{ service_name }}/servers/{{ service_name }}/weight"
       value: "1"
     - key: "traefik/frontends/{{ service_name }}/backend"
       value: "{{ service_name }}"
     - key: "traefik/frontends/{{ service_name }}/routes/{{ service_name }}/rule"
       value: "Host:{{ service_name }}.{{ local_domain_name }}"
+    - key: "traefik/frontends/{{ service_name }}/whitelist/sourcerange"
+      value: "{{ service_whitelist | default('0.0.0.0/0') }}"

--- a/docs/includes/_deploy.md.erb
+++ b/docs/includes/_deploy.md.erb
@@ -111,13 +111,13 @@ network).
 More labels are available, here is a list of the most common ones and if you want
 to know more about them check the [documentation](https://docs.traefik.io/toml/#docker-backend):
 
-label                                        | description
----------------------------------------------|-----------------------------------------
-`traefik.port=<int>`                         | On which port your app is listening
-`traefik.protocol=<string>`                  | If your app uses https you can define it here
-`traefik.enable=<bool>`                      | Allows you to disable the container (maybe for maintenance)
-`traefik.backend.loadbalancer.sticky=<bool>` | Allow usage of sticky sessions
-`traefik.frontend.rule=<string>`             | Alows overriding the domain the container is listening to, see [matchers](https://docs.traefik.io/basics/#matchers)
+label                                            | description
+-------------------------------------------------|-----------------------------------------
+`traefik.port=<int>`                             | On which port your app is listening
+`traefik.protocol=<string>`                      | If your app uses https you can define it here
+`traefik.enable=<bool>`                          | Allows you to disable the container (maybe for maintenance)
+`traefik.backend.loadbalancer.stickiness=<bool>` | Allow usage of sticky sessions
+`traefik.frontend.rule=<string>`                 | Alows overriding the domain the container is listening to, see [matchers](https://docs.traefik.io/basics/#matchers)
 
 ## Monitoring your deployment
 


### PR DESCRIPTION
Features
--------

  * IP whitelist for:
    - Kibana (*kibana_whitelist*)
    - Grafana (*grafana_whitelist*)
    - PHPLDAPAdmin (*phpldapadmin_whitelist*)
    - Docker registry (*registry_whitelist*)
    - Teleport (*teleport_whitelist*)
  * Configurable Docker Swarm network range (*swarm_network*)
  * Teleport: configurable cluster name (*teleport_cluster_name*)

Fixes
-----

  * PHPLDAPAdmin: disable HTTPS (since Traefik provides TLS termination)
  * Traefik integration: use traefik.backend.loadbalancer.stickiness
    instead of sticky

Service upgrades
----------------

  * AerisCloud.docker 1.2.1 -> 1.3.0
  * Elasticsearch 5.6.9 -> 6.2.4