### PR TITLE
portainer: allow customizing LDAP searches

### DIFF
--- a/docker-image/ansible/roles/portainer/defaults/main.yml
+++ b/docker-image/ansible/roles/portainer/defaults/main.yml
@@ -19,3 +19,7 @@ ldap_server: "{{ group_ipv4.control[0] }}"
 ldap_server_port: 389
 ldap_dc: "dc={{ local_domain_name.split('.') | join(',dc=') }}"
 ldap_admin_user: "cn=admin,{{ ldap_dc }}"
+
+portainer_ldap_user_search: "users,{{ ldap_dc }}"
+portainer_ldap_group_search: "groups,{{ ldap_dc }}"
+

--- a/docker-image/ansible/roles/portainer/templates/settings.json.j2
+++ b/docker-image/ansible/roles/portainer/templates/settings.json.j2
@@ -19,14 +19,14 @@
     "StartTLS": false,
     "SearchSettings": [
       {
-        "BaseDN": "ou=users,{{ ldap_dc }}",
+        "BaseDN": "{{ portainer_ldap_user_search }}",
         "Filter": "",
         "UserNameAttribute": "uid"
       }
     ],
     "GroupSearchSettings": [
       {
-        "GroupBaseDN": "ou=groups,{{ ldap_dc }}",
+        "GroupBaseDN": "{{ portainer_ldap_group_search }}",
         "GroupFilter": "",
         "GroupAttribute": "cn"
       }


### PR DESCRIPTION
make the user and group search filters customizable.

cc @k-t-yukana 