### PR TITLE
Grafana/add grafana datasource es version

### DIFF
--- a/buildconfig.yml
+++ b/buildconfig.yml
@@ -41,7 +41,7 @@ binary:
   name: "dawn"
 
   # The current version of the binary
-  version: "0.15.4"
+  version: "0.15.5"
 
   # (Optional) URLs to call when attempting auto-update.
   # Defaults:
@@ -78,7 +78,7 @@ image:
   name: dawn
 
   # Current image version
-  version: "0.15.4"
+  version: "0.15.5"
 
   # Root folder where most files will be uploaded or mounted
   root_folder: /dawn

--- a/docker-image/ansible/roles/grafana/defaults/main.yml
+++ b/docker-image/ansible/roles/grafana/defaults/main.yml
@@ -20,6 +20,8 @@ grafana_use_smtp: true
 grafana_stmp_host: "{{ smtp_hostname }}:{{ smtp_port }}"
 grafana_smtp_username: "{{ smtp_username }}"
 grafana_smtp_password: "{{ smtp_password }}"
+# Elasticsearch version as a number (2/5/56/60/70)
+grafana_datasource_es_version: 56
 
 ldap_server: "{{ group_ipv4.control[0] }}"
 ldap_server_port: 389

--- a/docker-image/ansible/roles/grafana/tasks/main.yml
+++ b/docker-image/ansible/roles/grafana/tasks/main.yml
@@ -87,7 +87,7 @@
       basicAuth: false
       database: "[elasticsearch_metrics-]YYYY.MM.DD"
       jsonData:
-        esVersion: 56
+        esVersion: "{{ grafana_datasource_es_version }}"
         interval: "Daily"
         keepCookies: []
         maxConcurrentShardRequests: 256


### PR DESCRIPTION
elasticsearch version7 support #83 の対応に伴い、grafanaのesVersionを指定できるよう対応