### PR TITLE
upgrade elasticsearch curator

### DIFF
--- a/buildconfig.yml
+++ b/buildconfig.yml
@@ -41,7 +41,7 @@ binary:
   name: "dawn"
 
   # The current version of the binary
-  version: "0.15.6"
+  version: "0.15.7"
 
   # (Optional) URLs to call when attempting auto-update.
   # Defaults:
@@ -78,7 +78,7 @@ image:
   name: dawn
 
   # Current image version
-  version: "0.15.6"
+  version: "0.15.7"
 
   # Root folder where most files will be uploaded or mounted
   root_folder: /dawn

--- a/docker-image/ansible/roles/elasticsearch/tasks/main.yml
+++ b/docker-image/ansible/roles/elasticsearch/tasks/main.yml
@@ -130,7 +130,7 @@
 
 - name: "Install curator"
   pip:
-    name: elasticsearch-curator==5.6.0
+    name: elasticsearch-curator==5.7.6
     virtualenv: /opt/dawn/deploy
     virtualenv_site_packages: yes
   when: groups['control'][0] == inventory_hostname


### PR DESCRIPTION
elasticsearch version7に対してes_purgeを実行した場合、`elasticsearch-curator`のバージョンが満たず実行時エラーになるため対応
